### PR TITLE
Convenience command to run current or last test with same key

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,12 +20,18 @@ By default extest.vim doesn't bind to any keys but is available in the form of c
 * `:ExTestRunFile` runs all the tests in the file that is loaded into the current buffer
 * `:ExTestRunTest` runs the test case under the cursor
 * `:ExTestRunLast` runs the last test, from any buffer
+* `:ExTestRunCurrentOrLast` runs test case under the cursor or the last test (from any buffer)
 
 If you want to bind those commands to your leader keys, you can do so nevertheless. For example:
 
 ```vim
 map <leader>T :ExTestRunFile<CR>
-map <leader>t :ExTestRunMethod<CR>
+map <leader>t :ExTestRunCurrentOrLast<CR>
+```
+or:
+```vim
+map <leader>T :ExTestRunFile<CR>
+map <leader>t :ExTestRunTest<CR>
 map <leader>lt :ExTestRunLast<CR>
 ```
 

--- a/plugin/extest.vim
+++ b/plugin/extest.vim
@@ -59,6 +59,17 @@ function s:RunLast()
   return s:RunCommand(g:extest_last_cmd)
 endfunction
 
+function s:RunTestOrLast()
+  let l:framework = s:IdentifyFramework()
+
+  if empty(l:framework)
+    return s:RunLast()
+  else
+    return s:RunTest()
+  endif
+endfunction
+
+
 " Starts a test run.
 " @param type ["test" | "file"]
 function s:ExecTestRun(type)

--- a/plugin/extest.vim
+++ b/plugin/extest.vim
@@ -41,6 +41,7 @@ endif
 command ExTestRunFile call <SID>RunFile()
 command ExTestRunTest call <SID>RunTest()
 command ExTestRunLast call <SID>RunLast()
+command ExTestRunCurrentOrLast call <SID>RunCurrentOrLast()
 
 function s:RunFile()
   return s:ExecTestRun("file")
@@ -59,7 +60,7 @@ function s:RunLast()
   return s:RunCommand(g:extest_last_cmd)
 endfunction
 
-function s:RunTestOrLast()
+function s:RunCurrentOrLast()
   let l:framework = s:IdentifyFramework()
 
   if empty(l:framework)


### PR DESCRIPTION
Use `ExTestRunCurrentOrLast()` to run test under cursor or last test from any buffer

``` vim
map <leader>t :ExTestRunCurrentOrLast<CR>
```
